### PR TITLE
cleaned up indexing typo in the 'write_dword' function

### DIFF
--- a/platform/src/vl53l0x_i2c_platform.c
+++ b/platform/src/vl53l0x_i2c_platform.c
@@ -289,9 +289,9 @@ int32_t VL53L0X_write_dword(uint8_t address, uint8_t index, uint32_t  data)
         uint8_t buffer[5]; /* Addr + data */
         buffer[0] = index;
         buffer[1] = data >> 24;
-        buffer[1] = data >> 16;
-        buffer[1] = data >> 8;
-        buffer[1] = data;
+        buffer[2] = data >> 16;
+        buffer[3] = data >> 8;
+        buffer[4] = data;
         ret = nrf_drv_twi_tx(&m_twi_master, address >> 1, buffer, 2, false);
     }while (0);
 


### PR DESCRIPTION
Hey Luke!  Thanks for setting up this driver!  It got me up and running with the nrf52840 in no time!
I found an issue in one of the files that bit me when trying to set the time interval between samples, turned out it was an indexing issue in the platform.c file outlined below.  Wanted to pass this along in case it helps somebody else in the future.

Thanks again...

Cheers,
Roger